### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -140,7 +140,7 @@ extension UnityAdsAdapter: UnityAdsInitializationDelegate {
     
     func initializationFailed(_ errorCode: UnityAdsInitializationError, withMessage message: String) {
         // Report initialization failure
-        let error = error(.initializationFailureUnknown, description: "\(errorCode) \(message)")
+        let error = partnerError(errorCode.rawValue, description: message)
         log(.setUpFailed(error))
         setUpCompletion?(error) ?? log("Setup result ignored")
         setUpCompletion = nil

--- a/Source/UnityAdsAdapterBannerAd.swift
+++ b/Source/UnityAdsAdapterBannerAd.swift
@@ -54,7 +54,7 @@ extension UnityAdsAdapterBannerAd: UADSBannerViewDelegate {
     
     func bannerViewDidError(_ bannerView: UADSBannerView?, partnerError: UADSBannerError?) {
         // Report load failure
-        let error = error(.loadFailureUnknown, error: partnerError)
+        let error = partnerError ?? error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil

--- a/Source/UnityAdsAdapterFullscreenAd.swift
+++ b/Source/UnityAdsAdapterFullscreenAd.swift
@@ -74,7 +74,7 @@ extension UnityAdsAdapterFullscreenAd: UnityAdsLoadDelegate {
     
     func unityAdsAdFailed(toLoad placementId: String, withError errorCode: UnityAdsLoadError, withMessage message: String) {
         // Report load failure
-        let error = error(.loadFailureUnknown, description: "\(errorCode) \(message)")
+        let error = partnerError(errorCode.rawValue, description: message)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil
@@ -92,7 +92,7 @@ extension UnityAdsAdapterFullscreenAd: UnityAdsShowDelegate {
     
     func unityAdsShowFailed(_ placementId: String, withError errorCode: UnityAdsShowError, withMessage message: String) {
         // Report show failure
-        let error = error(.showFailureUnknown, description: "\(errorCode) \(message)")
+        let error = partnerError(errorCode.rawValue, description: message)
         log(.showFailed(error))
         showCompletion?(.failure(error)) ?? log(.showResultIgnored)
         showCompletion = nil


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.  Also, partners that supply a code can create an error using the `PartnerAd.partnerError(_code:)` method instead.
