### PR TITLE
HB-4985: Fix delegate conformance to banner load error callback with wrong signature

### DIFF
--- a/Source/UnityAdsAdapterBannerAd.swift
+++ b/Source/UnityAdsAdapterBannerAd.swift
@@ -52,9 +52,9 @@ extension UnityAdsAdapterBannerAd: UADSBannerViewDelegate {
         loadCompletion = nil
     }
     
-    func bannerViewDidError(_ bannerView: UADSBannerView?, partnerError: UADSBannerError?) {
+    func bannerViewDidError(_ bannerView: UADSBannerView?, error: UADSBannerError?) {
         // Report load failure
-        let error = partnerError ?? error(.loadFailureUnknown)
+        let error = error ?? self.error(.loadFailureUnknown)
         log(.loadFailed(error))
         loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
         loadCompletion = nil


### PR DESCRIPTION
Method signature was wrong, so method would never get called.