### PR TITLE
Rename UnityAds -> Unity Ads

### DIFF
--- a/ChartboostHeliumAdapterUnityAds.podspec
+++ b/ChartboostHeliumAdapterUnityAds.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
 
   # Source
   spec.module_name  = 'HeliumAdapterUnityAds'
-  spec.source       = { :git => 'https://github.com/ChartBoost/helium-ios-adapter-unityads.git', :tag => spec.version }
+  spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
 
   # Minimum supported versions

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ pod 'ChartboostMediationAdapterUnityAds'
 
 We are committed to a fully transparent development process and highly appreciate any contributions. Our team regularly monitors and investigates all submissions for the inclusion in our official adapter releases.
 
-Refer to our [CONTRIBUTING](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unityads/blob/main/CONTRIBUTING.md) file for more information on how to contribute.
+Refer to our [CONTRIBUTING](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads/blob/main/CONTRIBUTING.md) file for more information on how to contribute.
 
 ## License
 
-Refer to our [LICENSE](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unityads/blob/main/LICENSE.md) file for more information.
+Refer to our [LICENSE](https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads/blob/main/LICENSE.md) file for more information.

--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -14,7 +14,7 @@ import Foundation
 import HeliumSdk
 import UnityAds
 
-/// The Helium UnityAds adapter.
+/// The Helium Unity Ads adapter.
 final class UnityAdsAdapter: NSObject, PartnerAdapter {
     
     /// The version of the partner SDK.
@@ -31,7 +31,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
     /// The human-friendly partner name.
     let partnerDisplayName = "Unity Ads"
         
-    /// The setUp completion received on setUp(), to be executed when UnityAds reports back its initialization status.
+    /// The setUp completion received on setUp(), to be executed when Unity Ads reports back its initialization status.
     private var setUpCompletion: ((Error?) -> Void)?
     
     /// The designated initializer for the adapter.
@@ -61,7 +61,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
         metaData.set(.adapterVersionKey, value: adapterVersion)
         metaData.commit()
         
-        // Initialize UnityAds
+        // Initialize Unity Ads
         setUpCompletion = completion
         UnityAds.initialize(gameID, testMode: false, initializationDelegate: self)
     }
@@ -70,7 +70,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
     /// - parameter request: Information about the ad load request.
     /// - parameter completion: Closure to be performed with the fetched info.
     func fetchBidderInformation(request: PreBidRequest, completion: @escaping ([String : String]?) -> Void) {
-        // UnityAds does not currently provide any bidding token
+        // Unity Ads does not currently provide any bidding token
         completion(nil)
     }
     
@@ -152,20 +152,20 @@ extension UnityAdsAdapter: UnityAdsInitializationDelegate {
     }
 }
 
-/// Convenience extension to access UnityAds credentials from the configuration.
+/// Convenience extension to access Unity Ads credentials from the configuration.
 private extension PartnerConfiguration {
     var gameID: String? { credentials[.gameIDKey] as? String }
 }
 
 private extension String {
-    /// UnityAds game ID credentials key.
+    /// Unity Ads game ID credentials key.
     static let gameIDKey = "game_id"
-    /// UnityAds metadata adapter version key.
+    /// Unity Ads metadata adapter version key.
     static let adapterVersionKey = "adapter_version"
-    /// UnityAds privacy userOverAgeLimit key.
+    /// Unity Ads privacy userOverAgeLimit key.
     static let userOverAgeLimitKey = "privacy.useroveragelimit"
-    /// UnityAds privacy GDPR consent key.
+    /// Unity Ads privacy GDPR consent key.
     static let gdprConsentKey = "gdpr.consent"
-    /// UnityAds privacy consent key.
+    /// Unity Ads privacy consent key.
     static let privacyConsentKey = "privacy.consent"
 }

--- a/Source/UnityAdsAdapterAd.swift
+++ b/Source/UnityAdsAdapterAd.swift
@@ -14,7 +14,7 @@ import UIKit
 import HeliumSdk
 import UnityAds
 
-/// Base class for Helium UnityAds adapter ads.
+/// Base class for Helium Unity Ads adapter ads.
 class UnityAdsAdapterAd: NSObject {
     
     /// The partner adapter that created this ad.

--- a/Source/UnityAdsAdapterBannerAd.swift
+++ b/Source/UnityAdsAdapterBannerAd.swift
@@ -14,7 +14,7 @@ import UIKit
 import HeliumSdk
 import UnityAds
 
-/// The Helium UnityAds adapter banner ad.
+/// The Helium Unity Ads adapter banner ad.
 final class UnityAdsAdapterBannerAd: UnityAdsAdapterAd, PartnerAd {
     
     /// The partner ad view to display inline. E.g. a banner view.

--- a/Source/UnityAdsAdapterFullscreenAd.swift
+++ b/Source/UnityAdsAdapterFullscreenAd.swift
@@ -14,14 +14,14 @@ import UIKit
 import HeliumSdk
 import UnityAds
 
-/// The Helium UnityAds adapter fullscreen ad.
+/// The Helium Unity Ads adapter fullscreen ad.
 final class UnityAdsAdapterFullscreenAd: UnityAdsAdapterAd, PartnerAd {
     
     /// The partner ad view to display inline. E.g. a banner view.
     /// Should be nil for full-screen ads.
     var inlineView: UIView? { nil }
     
-    /// A unique identifier passed in UnityAds load and show calls to identify the payload
+    /// A unique identifier passed in Unity Ads load and show calls to identify the payload
     private let payloadIdentifier = UUID().uuidString
     
     /// Loads an ad.
@@ -30,9 +30,9 @@ final class UnityAdsAdapterFullscreenAd: UnityAdsAdapterAd, PartnerAd {
     func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
         log(.loadStarted)
         
-        // Generate the UnityAds load options with the adm
+        // Generate the Unity Ads load options with the adm
         guard let options = UADSLoadOptions() else {
-            let error = error(.loadFailureAborted, description: "Failed to create UnityAds UADSLoadOptions")
+            let error = error(.loadFailureAborted, description: "Failed to create Unity Ads UADSLoadOptions")
             log(.loadFailed(error))
             completion(.failure(error))
             return
@@ -53,9 +53,9 @@ final class UnityAdsAdapterFullscreenAd: UnityAdsAdapterAd, PartnerAd {
     func show(with viewController: UIViewController, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
         log(.showStarted)
         
-        // Generate the UnityAds show options
+        // Generate the Unity Ads show options
         guard let options = UADSShowOptions() else {
-            let error = error(.showFailureUnknown, description: "Failed to create UnityAds UADSShowOptions")
+            let error = error(.showFailureUnknown, description: "Failed to create Unity Ads UADSShowOptions")
             log(.showFailed(error))
             completion(.failure(error))
             return


### PR DESCRIPTION
Renamed repo and uses of the "Unity Ads" name to include whitespace/hyphen when appropriate.

See https://chartboost.slack.com/archives/C019BTYC9MH/p1674510246502839