### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/6/22.
 //
 
+import ChartboostMediationSDK
 import Foundation
-import HeliumSdk
 import UnityAds
 
 /// The Helium Unity Ads adapter.

--- a/Source/UnityAdsAdapterAd.swift
+++ b/Source/UnityAdsAdapterAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/6/22.
 //
 
+import ChartboostMediationSDK
 import UIKit
-import HeliumSdk
 import UnityAds
 
 /// Base class for Helium Unity Ads adapter ads.

--- a/Source/UnityAdsAdapterBannerAd.swift
+++ b/Source/UnityAdsAdapterBannerAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/6/22.
 //
 
+import ChartboostMediationSDK
 import UIKit
-import HeliumSdk
 import UnityAds
 
 /// The Helium Unity Ads adapter banner ad.

--- a/Source/UnityAdsAdapterFullscreenAd.swift
+++ b/Source/UnityAdsAdapterFullscreenAd.swift
@@ -10,8 +10,8 @@
 //  Created by Daniel Barros on 10/6/22.
 //
 
+import ChartboostMediationSDK
 import UIKit
-import HeliumSdk
 import UnityAds
 
 /// The Helium Unity Ads adapter fullscreen ad.


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.