### PR TITLE
Fix showing of non-programmatic ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.4.5.0.1
+- Fix showing of non-programmatic ads.
+- This version of the adapters has been certified with UnityAds 4.5.0.
+
 ### 4.4.5.0.0
 - This version of the adapters has been certified with UnityAds 4.5.0.
 

--- a/ChartboostMediationAdapterUnityAds.podspec
+++ b/ChartboostMediationAdapterUnityAds.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterUnityAds'
-  spec.version     = '4.4.5.0.0'
+  spec.version     = '4.4.5.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-unity-ads'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }

--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -16,7 +16,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.4.5.0.0"
+    let adapterVersion = "4.4.5.0.1"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "unity"

--- a/Source/UnityAdsAdapterFullscreenAd.swift
+++ b/Source/UnityAdsAdapterFullscreenAd.swift
@@ -53,7 +53,9 @@ final class UnityAdsAdapterFullscreenAd: UnityAdsAdapterAd, PartnerAd {
             completion(.failure(error))
             return
         }
-        options.objectId = payloadIdentifier
+        if request.adm != nil {
+            options.objectId = payloadIdentifier
+        }
         
         // Show
         showCompletion = completion


### PR DESCRIPTION
The objectId set in the UADSShowOptions object must match the value for the same property in the UADSLoadOptions.
Non-programmatic loads had a mismatch where the objectId was nil when loading, but a UUID when showing, leading to show failures.