### PR TITLE
HB-5462: Support new ad format cases without warnings

### DIFF
--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -124,7 +124,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
             return try UnityAdsAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
         case .banner:
             return try UnityAdsAdapterBannerAd(adapter: self, request: request, delegate: delegate)
-        @unknown default:
+        default:
             throw error(.loadFailureUnsupportedAdFormat)
         }
     }


### PR DESCRIPTION
Removed the  keyword from the default case when switching on ad format, preventing warnings when new formats are introduced on newer Chartboost Mediation SDK versions.\nThe plan is to just merge this to main, and create new patch releases later on with the first 4.3 RCs with whatever the latest adapter version is.