### PR TITLE
Remove PartnerAdapterFormat.adaptive_banner

### DIFF
--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -131,7 +131,6 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
         // ChartboostMediationSDK 4.x does not support loading more than 2 banners with the same placement, and the partner may or may not support it.
         guard !storage.ads.contains(where: { $0.request.partnerPlacement == request.partnerPlacement })
             || request.format == PartnerAdFormats.banner
-            || request.format == PartnerAdFormats.adaptiveBanner
         else {
             log("Failed to load ad for already loading placement \(request.partnerPlacement)")
             throw error(.loadFailureLoadInProgress)
@@ -140,7 +139,7 @@ final class UnityAdsAdapter: NSObject, PartnerAdapter {
         switch request.format {
         case PartnerAdFormats.interstitial, PartnerAdFormats.rewarded:
             return try UnityAdsAdapterFullscreenAd(adapter: self, request: request, delegate: delegate)
-        case PartnerAdFormats.banner, PartnerAdFormats.adaptiveBanner:
+        case PartnerAdFormats.banner:
             return try UnityAdsAdapterBannerAd(adapter: self, request: request, delegate: delegate)
         default:
             throw error(.loadFailureUnsupportedAdFormat)

--- a/Source/UnityAdsAdapterBannerAd.swift
+++ b/Source/UnityAdsAdapterBannerAd.swift
@@ -25,7 +25,7 @@ final class UnityAdsAdapterBannerAd: UnityAdsAdapterAd, PartnerAd {
         log(.loadStarted)
 
         // Fail if we cannot fit a fixed size banner in the requested size.
-        guard let size = fixedBannerSize(for: request.size ?? IABStandardAdSize) else {
+        guard let size = fixedBannerSize(for: request.bannerSize) else {
             let error = error(.loadFailureInvalidBannerSize)
             log(.loadFailed(error))
             return completion(.failure(error))
@@ -89,13 +89,16 @@ extension UnityAdsAdapterBannerAd: UADSBannerViewDelegate {
 
 // MARK: - Helpers
 extension UnityAdsAdapterBannerAd {
-    private func fixedBannerSize(for requestedSize: CGSize) -> CGSize? {
+    private func fixedBannerSize(for requestedSize: BannerSize?) -> CGSize? {
+        guard let requestedSize else {
+            return IABStandardAdSize
+        }
         let sizes = [IABLeaderboardAdSize, IABMediumAdSize, IABStandardAdSize]
         // Find the largest size that can fit in the requested size.
         for size in sizes {
             // If height is 0, the pub has requested an ad of any height, so only the width matters.
-            if requestedSize.width >= size.width &&
-                (size.height == 0 || requestedSize.height >= size.height) {
+            if requestedSize.size.width >= size.width &&
+                (size.height == 0 || requestedSize.size.height >= size.height) {
                 return size
             }
         }


### PR DESCRIPTION
Updated implementation for removal of PartnerAdapterFormats.adaptive_banner and additiong of a BannerSize property in PartnerAdLoadRequest