### PR TITLE
HB-7647: Configuration class rework

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -25,7 +25,7 @@ jobs:
   create-release-branch:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/create-adapter-release-branch@v2
         with:
           adapter-version: ${{ inputs.adapter-version || github.event.client_payload.adapter-version }}
           partner-version: ${{ inputs.partner-version || github.event.client_payload.partner-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,4 +12,4 @@ jobs:
   release-adapter:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/release-adapter@v2

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,4 +12,4 @@ jobs:
   validate-podspec:
     runs-on: macos-14
     steps:
-      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v1
+      - uses: chartboost/chartboost-mediation-ios-actions/adapter-smoke-test@v2

--- a/Source/UnityAdsAdapter.swift
+++ b/Source/UnityAdsAdapter.swift
@@ -9,21 +9,29 @@ import UnityAds
 
 /// The Chartboost Mediation Unity Ads adapter.
 final class UnityAdsAdapter: NSObject, PartnerAdapter {
-    
+
     /// The version of the partner SDK.
-    let partnerSDKVersion = UnityAds.getVersion()
-    
+    var partnerSDKVersion: String {
+        UnityAdsAdapterConfiguration.partnerSDKVersion
+    }
+
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.4.10.0.0"
-    
+    var adapterVersion: String {
+        UnityAdsAdapterConfiguration.adapterVersion
+    }
+
     /// The partner's unique identifier.
-    let partnerID = "unity"
-    
+    var partnerID: String {
+        UnityAdsAdapterConfiguration.partnerID
+    }
+
     /// The human-friendly partner name.
-    let partnerDisplayName = "Unity Ads"
-    
+    var partnerDisplayName: String {
+        UnityAdsAdapterConfiguration.partnerDisplayName
+    }
+
     /// Ad storage managed by Chartboost Mediation SDK.
     let storage: PartnerAdapterStorage
     

--- a/Source/UnityAdsAdapterConfiguration.swift
+++ b/Source/UnityAdsAdapterConfiguration.swift
@@ -1,0 +1,26 @@
+// Copyright 2023-2024 Chartboost, Inc.
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file.
+
+import Foundation
+import UnityAds
+
+@objc public class UnityAdsAdapterConfiguration: NSObject {
+
+    /// The version of the partner SDK.
+    @objc static var partnerSDKVersion: String {
+        UnityAds.getVersion()
+    }
+
+    /// The version of the adapter.
+    /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
+    /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
+    @objc static let adapterVersion = "4.4.10.0.0"
+
+    /// The partner's unique identifier.
+    @objc static let partnerID = "unity"
+
+    /// The human-friendly partner name.
+    @objc static let partnerDisplayName = "Unity Ads"
+}

--- a/Source/UnityAdsAdapterConfiguration.swift
+++ b/Source/UnityAdsAdapterConfiguration.swift
@@ -4,6 +4,7 @@
 // license that can be found in the LICENSE file.
 
 import Foundation
+import os.log
 import UnityAds
 
 @objc public class UnityAdsAdapterConfiguration: NSObject {

--- a/Source/UnityAdsAdapterConfiguration.swift
+++ b/Source/UnityAdsAdapterConfiguration.swift
@@ -9,20 +9,20 @@ import UnityAds
 @objc public class UnityAdsAdapterConfiguration: NSObject {
 
     /// The version of the partner SDK.
-    @objc static var partnerSDKVersion: String {
+    @objc public static var partnerSDKVersion: String {
         UnityAds.getVersion()
     }
 
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    @objc static let adapterVersion = "4.4.10.0.0"
+    @objc public static let adapterVersion = "4.4.10.0.0"
 
     /// The partner's unique identifier.
-    @objc static let partnerID = "unity"
+    @objc public static let partnerID = "unity"
 
     /// The human-friendly partner name.
-    @objc static let partnerDisplayName = "Unity Ads"
+    @objc public static let partnerDisplayName = "Unity Ads"
 
     /// Flag that can optionally be set to enable the partner's debug mode.
     /// Disabled by default.

--- a/Source/UnityAdsAdapterConfiguration.swift
+++ b/Source/UnityAdsAdapterConfiguration.swift
@@ -23,4 +23,18 @@ import UnityAds
 
     /// The human-friendly partner name.
     @objc static let partnerDisplayName = "Unity Ads"
+
+    /// Flag that can optionally be set to enable the partner's debug mode.
+    /// Disabled by default.
+    @objc public static var debugMode: Bool {
+        get {
+            UnityAds.getDebugMode()
+        }
+        set {
+            UnityAds.setDebugMode(newValue)
+            os_log(.debug, log: log, "Unity Ads SDK test mode set to %{public}s", "\(newValue)")
+        }
+    }
+
+    private static let log = OSLog(subsystem: "com.chartboost.mediation.adapter.unityads", category: "Configuration")
 }

--- a/Source/UnityAdsAdapterConfiguration.swift
+++ b/Source/UnityAdsAdapterConfiguration.swift
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Chartboost, Inc.
+// Copyright 2022-2024 Chartboost, Inc.
 //
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.


### PR DESCRIPTION
Move module property definitions to the public Configuration class to expose them to pubs and Unity. Add missing configuration options for parity with Android.